### PR TITLE
feat: reduce navbar transparency

### DIFF
--- a/app/components/header-section/Header.tsx
+++ b/app/components/header-section/Header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
   return (
     <>
       <div className="fixed max-w-[90%] xl:max-w-[1223px] w-full z-10 select-none">
-        <div className="flex justify-between items-center px-6 py-4 rounded-2xl bg-linear-to-r from-[#d9d9d91f] to-[#7373731f] mt-4 sm:mt-8 std-backdrop-blur">
+        <div className="flex justify-between items-center px-6 py-4 rounded-2xl bg-linear-to-r from-[#d9d9d980] to-[#73737380] mt-4 sm:mt-8 std-backdrop-blur">
           <Image
             src="/logo.svg"
             width={32}


### PR DESCRIPTION
The navbar was too transparent, making the content difficult to see. This commit reduces the transparency of the navbar by changing the alpha value of the background gradient from 12% to 50%.